### PR TITLE
Fix abstdraw fallback and add exit pause

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ reproducible for the same inputs.
 
 ## Requirements
 
-- Python 3 with `numpy` and `requests`
+The script only needs Python 3. It optionally uses `numpy` and `requests` for
+faster point generation and fetching the current weather. If these packages are
+not available the program will still run, but the art will be generated using
+Python's built in random module and the weather will be reported as "Unknown".
 
-Install the dependencies with:
+To enable the optional features install the extra packages:
 
 ```bash
 pip install numpy requests


### PR DESCRIPTION
## Summary
- make `numpy` and `requests` optional dependencies
- fallback to Python's `random` if `numpy` is missing
- handle missing `requests`
- update README to reflect optional packages
- prompt the user to press enter before exit

## Testing
- `python3 abstdraw.py <<'EOF'
50
hello world

EOF`

------
https://chatgpt.com/codex/tasks/task_e_685983c11f2c832fb278342dc84ebc98