### PR TITLE
Improve drawing variability based on input

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 the current date, the local weather (fetched from `wttr.in`), an energy level
 digit, and a short text prompt.  These values determine a random seed so the art
 is reproducible for the same inputs.  The drawing is displayed in a window using
-golden ratio proportions.
+golden ratio proportions.  The color of the lines is derived from the energy
+digit, the text controls how chaotic the pattern becomes, and the energy level
+also determines how many obstacle shapes are drawn on top of the art.
 
 ## Requirements
 
@@ -28,4 +30,6 @@ python abstdraw.py
 ```
 
 The generated abstract art will open in a window.  If `tkinter` is unavailable
-the program falls back to ASCII art output.
+the program falls back to ASCII art output.  Colors vary with the energy level,
+the diversity of the words adds more chaotic noise, and higher energy values
+add more obstacle rectangles to the drawing.


### PR DESCRIPTION
## Summary
- vary line color based on energy digit
- use words to control chaotic noise level
- add obstacle shapes controlled by energy level
- document new features in README

## Testing
- `python -m py_compile abstdraw.py`
- `python abstdraw.py <<'EOF'
5
chaos test

EOF`

------
https://chatgpt.com/codex/tasks/task_e_685991020b68832fb3bc2ef5ec280b58